### PR TITLE
QUICKFIX InconsistenWithEndCustomer Cdtr/PstlAdr

### DIFF
--- a/account_banking_pain_base/models/account_payment_order.py
+++ b/account_banking_pain_base/models/account_payment_order.py
@@ -409,19 +409,25 @@ class AccountPaymentOrder(models.Model):
         partner = partner_bank.partner_id
         if partner.country_id:
             postal_address = etree.SubElement(party, 'PstlAdr')
-            if gen_args.get('pain_flavor').startswith(
-                    'pain.001.001.') or gen_args.get('pain_flavor').startswith(
-                    'pain.008.001.'):
-                if partner.zip:
-                    pstcd = etree.SubElement(postal_address, 'PstCd')
-                    pstcd.text = self._prepare_field(
-                        'Postal Code', 'partner.zip',
-                        {'partner': partner}, 16, gen_args=gen_args)
-                if partner.city:
-                    twnnm = etree.SubElement(postal_address, 'TwnNm')
-                    twnnm.text = self._prepare_field(
-                        'Town Name', 'partner.city',
-                        {'partner': partner}, 35, gen_args=gen_args)
+
+            ###########################################################
+            # [t113547] FIX: SEPA
+            ###########################################################
+
+            # if gen_args.get('pain_flavor').startswith(
+            #         'pain.001.001.') or gen_args.get('pain_flavor').startswith(
+            #         'pain.008.001.'):
+            #     if partner.zip:
+            #         pstcd = etree.SubElement(postal_address, 'PstCd')
+            #         pstcd.text = self._prepare_field(
+            #             'Postal Code', 'partner.zip',
+            #             {'partner': partner}, 16, gen_args=gen_args)
+            #     if partner.city:
+            #         twnnm = etree.SubElement(postal_address, 'TwnNm')
+            #         twnnm.text = self._prepare_field(
+            #             'Town Name', 'partner.city',
+            #             {'partner': partner}, 35, gen_args=gen_args)
+
             country = etree.SubElement(postal_address, 'Ctry')
             country.text = self._prepare_field(
                 'Country', 'partner.country_id.code',
@@ -430,6 +436,12 @@ class AccountPaymentOrder(models.Model):
                 adrline1 = etree.SubElement(postal_address, 'AdrLine')
                 adrline1.text = self._prepare_field(
                     'Adress Line1', 'partner.street',
+                    {'partner': partner}, 70, gen_args=gen_args)
+
+            if partner.city and partner.zip:
+                adrline2 = etree.SubElement(postal_address, 'AdrLine')
+                adrline2.text = self._prepare_field(
+                    'Address Line2', "partner.zip + ' ' + partner.city",
                     {'partner': partner}, 70, gen_args=gen_args)
 
         self.generate_party_id(party, party_type, partner)

--- a/account_banking_pain_base/models/account_payment_order.py
+++ b/account_banking_pain_base/models/account_payment_order.py
@@ -415,8 +415,8 @@ class AccountPaymentOrder(models.Model):
             ###########################################################
 
             # if gen_args.get('pain_flavor').startswith(
-            #         'pain.001.001.') or gen_args.get('pain_flavor').startswith(
-            #         'pain.008.001.'):
+            #         'pain.001.001.') or gen_args.get('pain_flavor')
+            #         .startswith('pain.008.001.'):
             #     if partner.zip:
             #         pstcd = etree.SubElement(postal_address, 'PstCd')
             #         pstcd.text = self._prepare_field(


### PR DESCRIPTION
Solved temporarily:

    Fehler
    --------------------------------------------------------------------
    Fehler im Aufbau des XML-Elements /Document/CstmrCdtTrfInitn/PmtInf[1]/CdtTrfTxInf[1]/Cdtr/PstlAdr
    Fehlermeldung:
        Strukturierte Adressdaten sind zusammen mit unstrukturierten Daten ung¸ltig.
    Fehlercode:
        BE01 (InconsistenWithEndCustomer)
    Dateiposition:
        Zeile:  61
        Spalte: 19

In the end we need to have ESR, QR with a structured address and SEPA and foreign countries with unstructured.